### PR TITLE
Allow to build jobs with/without parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,13 @@
 # Change Log
 
+# 0.3.0
+
+- Remove parameter 'branch'. Add optional parameter 'parameters'
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.
 
 # 0.1.0
 
-- First release 
+- First release

--- a/actions/build_job.py
+++ b/actions/build_job.py
@@ -2,5 +2,5 @@ from lib import action
 
 
 class BuildProject(action.JenkinsBaseAction):
-    def run(self, project, branch="master"):
-        return self.jenkins.build_job(project, {'branch': branch})
+    def run(self, project, parameters=None):
+        return self.jenkins.build_job(project, parameters)

--- a/actions/build_job.yaml
+++ b/actions/build_job.yaml
@@ -8,6 +8,6 @@ parameters:
         type: string
         description: "Project to build in Jenkins"
         required: true
-    branch:
-        type: string
-        description: "Git branch to build in Jenkins"
+    parameters:
+        type: object
+        description: "Optional parameters for build in JSON format"

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: jenkins
 name: jenkins
 description: Jenkins CI Integration Pack
-version: 0.2.0
+version: 0.3.0
 author: James Fryman
 email: james@stackstorm.com


### PR DESCRIPTION
This fix allow to build jobs without parameters, or add other, except hardcoded "branch"