### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.4.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.3.0
 
 - Remove parameter 'branch'. Add optional parameter 'parameters'

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ to `/opt/stackstorm/configs/jenkins.yaml` and edit as required.
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 * `build_job` - Kick off CI build based on project name

--- a/actions/build_job.yaml
+++ b/actions/build_job.yaml
@@ -1,5 +1,5 @@
 name: build_job
-runner_type: run-python
+runner_type: python-script
 description: "Kick off Jenkins Build Jobs"
 enabled: true
 entry_point: "build_job.py"

--- a/actions/disable_job.yaml
+++ b/actions/disable_job.yaml
@@ -1,6 +1,6 @@
 ---
 name: "disable_job"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Disable Jenkins Job."
 enabled: true
 entry_point: "disable_job.py"

--- a/actions/enable_job.yaml
+++ b/actions/enable_job.yaml
@@ -1,6 +1,6 @@
 ---
 name: "enable_job"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Enable Jenkins Job."
 enabled: true
 entry_point: "enable_job.py"

--- a/actions/get_job_info.yaml
+++ b/actions/get_job_info.yaml
@@ -1,6 +1,6 @@
 ---
 name: "get_job_info"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Retrieve job information"
 enabled: true
 entry_point: "get_job_info.py"

--- a/actions/install_plugin.yaml
+++ b/actions/install_plugin.yaml
@@ -1,6 +1,6 @@
 ---
 name: "install_plugin"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Install Jenkins plugin."
 enabled: true
 entry_point: "install_plugin.py"

--- a/actions/list_running_jobs.yaml
+++ b/actions/list_running_jobs.yaml
@@ -1,6 +1,6 @@
 ---
 name: list_running_jobs
-runner_type: run-python
+runner_type: python-script
 description: "List currently running Jenkins jobs"
 enabled: true
 entry_point: "list_running_jobs.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: jenkins
 name: jenkins
 description: Jenkins CI Integration Pack
-version: 0.3.0
+version: 0.4.0
 author: James Fryman
 email: james@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.