### PR TITLE
v0.7.6 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.7.2
+
+- All actions got `config_override` optional parameter to support multi-tenancy. The paramater takes an object with `url`, `username` and `password` keys with appropriate values to contact arbitrary Jenkins instance instead of the one configured in the global pack configuration.
+
 # 0.7.1
 
 - Added `get_job_params` action to get all params of a certain job and their default values, and optionally merge it with user provided params.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# 0.7.5
+
+- Added `get_queue_info` action.
+- Added `cancel_queued_build` action.
+
 # 0.7.4
 
 - `get_running_builds` now decodes/unquotes jobs' names and adds them as `name_decoded` into the resulting array.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.7.4
+
+- `get_running_builds` now decodes/unquotes jobs' names and adds them as `name_decoded` into the resulting array.
+
 # 0.7.3
 
 Security release.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ Security release.
 
 # 0.7.2
 
-- All actions got `config_override` optional parameter to support multi-tenancy. The paramater takes an object with `url`, `username` and `password` keys with appropriate values to contact arbitrary Jenkins instance instead of the one configured in the global pack configuration.
+- All actions got `config_override` optional parameter to support multi-tenancy. The parameter takes an object with `url`, `username` and `password` keys with appropriate values to contact arbitrary Jenkins instance instead of the one configured in the global pack configuration.
 
 # 0.7.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.7.6
+
+- If `build_job_enh` fails and `queue_id` is known, include it in the result to let users follow up later.
+
 # 0.7.5
 
 - Added `get_queue_info` action.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# 0.7.3
+
+Security release.
+- `config_override` optional parameter is marked as secret so whatever is provided there is not exposed in the UI.
+
 # 0.7.2
 
 - All actions got `config_override` optional parameter to support multi-tenancy. The paramater takes an object with `url`, `username` and `password` keys with appropriate values to contact arbitrary Jenkins instance instead of the one configured in the global pack configuration.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.7.1
+
+- Added `get_job_params` action to get all params of a certain job and their default values, and optionally merge it with user provided params.
+
 # 0.7.0
 
 - Added `get_running_builds` action to get all currently running builds.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ for this pack to be able to start jobs.
 
 ## Configuration
 
+# Modern way
+Once the pack is installed, issue `st2 pack config jenkins` command to enter url, username and password (if auth is enabled) of your primary Jenkins instance.
+
+# Legacy way
 Copy the example configuration in [jenkins.yaml.example](./jenkins.yaml.example)
 to `/opt/stackstorm/configs/jenkins.yaml` and edit as required.
 
@@ -21,6 +25,8 @@ to `/opt/stackstorm/configs/jenkins.yaml` and edit as required.
 
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
+
+**Note** : Configuration can be overridden per each action execution. See below. 
 
 **Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
            remember to tell StackStorm to load these new values by running
@@ -34,6 +40,8 @@ You can also use dynamic values from the datastore. See the
            to apply the changes.
 
 ## Actions
+
+**Note** : As of v0.7.2 each action supports optional `config_override` parameter to override `url`, `username` and `password` configuration values. Pass it as an object, e.g. `{"url": "http://someotherjenkinshost.example.com:8080", "username": "user1", "password": "somepassword"}` or `{"url": "http://someotherjenkinshost.example.com:8080"}` if auth is not required. 
 
 * `build_job` - Kick off CI build based on project name
 * `build_job_enh` - Kick off CI build based on project name and wait for it to be executed, return build info

--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ You can also use dynamic values from the datastore. See the
 * `get_job_params` - Retrieve Jenkins job params with default values and merge with the provided dict of params, if any 
 * `get_build_info` - Retrieve Jenkins build information
 * `get_running_builds` - Retrieve all running Jenkins builds (possible to filter with regex by name)
+* `get_queue_info` - Retrieve queue information from the Jenkins instance
 * `install_plugin` - Install plugin
 * `rebuild_last_job` - Rebuild last Jenkins job
 * `list_jobs_regex` - List Jenkins job name by regex pattern
 * `stop_build` - Stop a running Jenkins build
+* `cancel_queued_build` - Cancel a queued build
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You can also use dynamic values from the datastore. See the
 * `enable_job` - Enable Jenkins job
 * `disable_job` - Disable Jenkins job
 * `get_job_info` - Retrieve Jenkins job information
+* `get_job_params` - Retrieve Jenkins job params with default values and merge with the provided dict of params, if any 
 * `get_build_info` - Retrieve Jenkins build information
 * `get_running_builds` - Retrieve all running Jenkins builds (possible to filter with regex by name)
 * `install_plugin` - Install plugin

--- a/actions/build_job.py
+++ b/actions/build_job.py
@@ -2,5 +2,7 @@ from lib import action
 
 
 class BuildProject(action.JenkinsBaseAction):
-    def run(self, project, parameters=None):
+    def run(self, project, parameters=None, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
         return self.jenkins.build_job(project, parameters)

--- a/actions/build_job.yaml
+++ b/actions/build_job.yaml
@@ -11,3 +11,7 @@ parameters:
     parameters:
         type: object
         description: "Optional parameters for build in JSON format"
+  config_override:
+    type: "object"
+    required: false
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/build_job.yaml
+++ b/actions/build_job.yaml
@@ -14,4 +14,5 @@ parameters:
   config_override:
     type: "object"
     required: false
+    secret: true
     description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/build_job.yaml
+++ b/actions/build_job.yaml
@@ -4,13 +4,13 @@ description: "Kick off Jenkins Build Jobs"
 enabled: true
 entry_point: "build_job.py"
 parameters:
-    project:
-        type: string
-        description: "Project to build in Jenkins"
-        required: true
-    parameters:
-        type: object
-        description: "Optional parameters for build in JSON format"
+  project:
+    type: string
+    description: "Project to build in Jenkins"
+    required: true
+  parameters:
+    type: object
+    description: "Optional parameters for build in JSON format"
   config_override:
     type: "object"
     required: false

--- a/actions/build_job_enh.py
+++ b/actions/build_job_enh.py
@@ -1,6 +1,6 @@
 from lib import action
 from time import sleep
-from jenkins import NotFoundException
+from jenkins import NotFoundException, JenkinsException
 
 
 class BuildProject(action.JenkinsBaseAction):
@@ -11,6 +11,8 @@ class BuildProject(action.JenkinsBaseAction):
             queue_id = self.jenkins.build_job(project, parameters)
         except NotFoundException:
             return False, {'error': 'Project {0} not found.'.format(project)}
+        except JenkinsException as e:
+            return False, {'error': 'General error: {0}'.format(e)}
         attempt = 0
         sleep_interval = 3
         max_attempts = int(max_wait / sleep_interval)

--- a/actions/build_job_enh.py
+++ b/actions/build_job_enh.py
@@ -33,9 +33,10 @@ class BuildProject(action.JenkinsBaseAction):
                 sleep(sleep_interval)
 
         if not run_build_result and 'why' in queue_item:
-            return run_build_result, queue_item['why']
+            return run_build_result, {'error': queue_item['why'], 'queue_id': queue_id}
         elif not run_build_result and 'why' not in queue_item:
-            return run_build_result, {'error': 'General failure for queue_id {0}.'.format(queue_id)}
+            return run_build_result, {'error': 'General failure for queue_id {0}.'.format(queue_id),
+                                      'queue_id': queue_id}
         else:
             return run_build_result, queue_item['executable']
 
@@ -49,11 +50,11 @@ class BuildProject(action.JenkinsBaseAction):
             msg = e.message
             msg = msg.encode('ascii', 'ignore')
             if 'doBuildWithParameters' in msg:
-                # most likely build is not parameterized but we sent parameters, return non-terminal status
+                # most likely build is not parameterized but we sent parameters,
+                # return non-terminal status
                 return 1, {}
             else:
                 # most likely something else and very bad happened, return terminal status
                 return 2, {'error': 'General error: {0}'.format(msg)}
         else:
             return 0, queue_id
-

--- a/actions/build_job_enh.py
+++ b/actions/build_job_enh.py
@@ -7,12 +7,17 @@ class BuildProject(action.JenkinsBaseAction):
     def run(self, project, max_wait=30, parameters=None, config_override=None):
         if config_override is not None:
             self.config_override(config_override)
-        try:
-            queue_id = self.jenkins.build_job(project, parameters)
-        except NotFoundException:
-            return False, {'error': 'Project {0} not found.'.format(project)}
-        except JenkinsException as e:
-            return False, {'error': 'General error: {0}'.format(e)}
+        (status, queue_id) = self.kick_off_job(project, parameters)
+        if status == 1:
+            # try again without parameters
+            (status, queue_id) = self.kick_off_job(project, {})
+            if status > 0:
+                # give up
+                return False, queue_id
+        elif status == 2:
+            # queue_id will contain error
+            return False, queue_id
+
         attempt = 0
         sleep_interval = 3
         max_attempts = int(max_wait / sleep_interval)
@@ -33,3 +38,22 @@ class BuildProject(action.JenkinsBaseAction):
             return run_build_result, {'error': 'General failure for queue_id {0}.'.format(queue_id)}
         else:
             return run_build_result, queue_item['executable']
+
+    def kick_off_job(self, prj, prm):
+        try:
+            queue_id = self.jenkins.build_job(prj, prm)
+        except NotFoundException:
+            # terminal error
+            return 2, {'error': 'Project {0} not found.'.format(prj)}
+        except JenkinsException as e:
+            msg = e.message
+            msg = msg.encode('ascii', 'ignore')
+            if 'doBuildWithParameters' in msg:
+                # most likely build is not parameterized but we sent parameters, return non-terminal status
+                return 1, {}
+            else:
+                # most likely something else and very bad happened, return terminal status
+                return 2, {'error': 'General error: {0}'.format(msg)}
+        else:
+            return 0, queue_id
+

--- a/actions/build_job_enh.py
+++ b/actions/build_job_enh.py
@@ -4,7 +4,9 @@ from jenkins import NotFoundException
 
 
 class BuildProject(action.JenkinsBaseAction):
-    def run(self, project, max_wait=30, parameters=None):
+    def run(self, project, max_wait=30, parameters=None, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
         try:
             queue_id = self.jenkins.build_job(project, parameters)
         except NotFoundException:

--- a/actions/build_job_enh.yaml
+++ b/actions/build_job_enh.yaml
@@ -18,4 +18,5 @@ parameters:
   config_override:
     type: "object"
     required: false
+    secret: true
     description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/build_job_enh.yaml
+++ b/actions/build_job_enh.yaml
@@ -4,17 +4,17 @@ description: "Kick off Jenkins Build Jobs (return enhanced info)"
 enabled: true
 entry_point: "build_job_enh.py"
 parameters:
-    project:
-        type: "string"
-        description: "Project to build in Jenkins"
-        required: true
-    parameters:
-        type: "object"
-        description: "Optional parameters for build in JSON format"
-    max_wait:
-        type: "integer"
-        description: "Seconds to wait for executor, default 30s"
-        default: 30
+  project:
+    type: "string"
+    description: "Project to build in Jenkins"
+    required: true
+  parameters:
+    type: "object"
+    description: "Optional parameters for build in JSON format"
+  max_wait:
+    type: "integer"
+    description: "Seconds to wait for executor, default 30s"
+    default: 30
   config_override:
     type: "object"
     required: false

--- a/actions/build_job_enh.yaml
+++ b/actions/build_job_enh.yaml
@@ -15,3 +15,7 @@ parameters:
         type: "integer"
         description: "Seconds to wait for executor, default 30s"
         default: 30
+  config_override:
+    type: "object"
+    required: false
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/cancel_queued_build.py
+++ b/actions/cancel_queued_build.py
@@ -1,0 +1,12 @@
+from lib import action
+from jenkins import NotFoundException
+
+
+class CancelQueuedBuild(action.JenkinsBaseAction):
+    def run(self, job_id, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
+        try:
+            return self.jenkins.cancel_queue(job_id)
+        except NotFoundException as e:
+            return False, {'error': str(e)}

--- a/actions/cancel_queued_build.yaml
+++ b/actions/cancel_queued_build.yaml
@@ -1,0 +1,15 @@
+name: cancel_queued_build
+runner_type: python-script
+description: "Cancel a queued build"
+enabled: true
+entry_point: "cancel_queued_build.py"
+parameters:
+  job_id:
+    type: "integer"
+    description: "Jenkins job id for the queued build."
+    required: true
+  config_override:
+    type: "object"
+    required: false
+    secret: true
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/disable_job.py
+++ b/actions/disable_job.py
@@ -2,5 +2,7 @@ from lib import action
 
 
 class DisableProject(action.JenkinsBaseAction):
-    def run(self, name):
+    def run(self, name, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
         return self.jenkins.disable_job(name)

--- a/actions/disable_job.yaml
+++ b/actions/disable_job.yaml
@@ -12,4 +12,5 @@ parameters:
   config_override:
     type: "object"
     required: false
+    secret: true
     description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/disable_job.yaml
+++ b/actions/disable_job.yaml
@@ -9,3 +9,7 @@ parameters:
     type: "string"
     description: "Name of the job to disable."
     required: true
+  config_override:
+    type: "object"
+    required: false
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/enable_job.py
+++ b/actions/enable_job.py
@@ -2,5 +2,7 @@ from lib import action
 
 
 class EnableProject(action.JenkinsBaseAction):
-    def run(self, name):
+    def run(self, name, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
         return self.jenkins.enable_job(name)

--- a/actions/enable_job.yaml
+++ b/actions/enable_job.yaml
@@ -12,4 +12,5 @@ parameters:
   config_override:
     type: "object"
     required: false
+    secret: true
     description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/enable_job.yaml
+++ b/actions/enable_job.yaml
@@ -9,3 +9,7 @@ parameters:
     type: "string"
     description: "Name of the job to enable."
     required: true
+  config_override:
+    type: "object"
+    required: false
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/get_build_info.py
+++ b/actions/get_build_info.py
@@ -3,7 +3,9 @@ from jenkins import JenkinsException
 
 
 class GetBuildInfo(action.JenkinsBaseAction):
-    def run(self, project, number, depth):
+    def run(self, project, number, depth, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
         try:
             build_info = self.jenkins.get_build_info(project, number, depth=depth)
             return build_info

--- a/actions/get_build_info.yaml
+++ b/actions/get_build_info.yaml
@@ -21,4 +21,5 @@ parameters:
   config_override:
     type: "object"
     required: false
+    secret: true
     description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/get_build_info.yaml
+++ b/actions/get_build_info.yaml
@@ -18,3 +18,7 @@ parameters:
     description: "JSON depth"
     default: 0
     required: false
+  config_override:
+    type: "object"
+    required: false
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/get_job_info.py
+++ b/actions/get_job_info.py
@@ -2,5 +2,7 @@ from lib import action
 
 
 class GetJobInfo(action.JenkinsBaseAction):
-    def run(self, project):
+    def run(self, project, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
         return self.jenkins.get_job_info(project, depth=0, fetch_all_builds='False')

--- a/actions/get_job_info.yaml
+++ b/actions/get_job_info.yaml
@@ -9,3 +9,7 @@ parameters:
     type: "string"
     description: "Name of the Jenkins job"
     required: true
+  config_override:
+    type: "object"
+    required: false
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/get_job_info.yaml
+++ b/actions/get_job_info.yaml
@@ -12,4 +12,5 @@ parameters:
   config_override:
     type: "object"
     required: false
+    secret: true
     description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/get_job_params.py
+++ b/actions/get_job_params.py
@@ -21,7 +21,8 @@ class GetJobParams(action.JenkinsBaseAction):
                 for p_def in i['parameterDefinitions']:
                     try:
                         job_params[p_def['name']] = p_def['defaultParameterValue']['value']
-                        self.logger.debug("Adding param %s with value %s", p_def['name'], p_def['defaultParameterValue']['value'])
+                        self.logger.debug("Adding param %s with value %s", p_def['name'],
+                                          p_def['defaultParameterValue']['value'])
                     except KeyError as e:
                         self.logger.debug("Exception %s when reading param %s", e, p_def['name'])
                         continue

--- a/actions/get_job_params.py
+++ b/actions/get_job_params.py
@@ -1,0 +1,36 @@
+from lib import action
+
+
+class GetJobParams(action.JenkinsBaseAction):
+    def run(self, project, params):
+
+        job_info = self.jenkins.get_job_info(project, depth=0, fetch_all_builds='False')
+        try:
+            job_actions = job_info['actions']
+        except KeyError:
+            job_actions = []
+        self.logger.debug("Read jobs config: %s", job_actions)
+        job_params = {}
+        for i in job_actions:
+            try:
+                cls = i['_class']
+            except KeyError:
+                continue
+            self.logger.debug("Class detected as: %s", cls)
+            if cls == 'hudson.model.ParametersDefinitionProperty':
+                for p_def in i['parameterDefinitions']:
+                    try:
+                        job_params[p_def['name']] = p_def['defaultParameterValue']['value']
+                        self.logger.debug("Adding param %s with value %s", p_def['name'], p_def['defaultParameterValue']['value'])
+                    except KeyError as e:
+                        self.logger.debug("Exception %s when reading param %s", e, p_def['name'])
+                        continue
+
+        params = self.merge_dicts(job_params, params)
+        return True, params
+
+    @staticmethod
+    def merge_dicts(dict1, dict2):
+        d = dict1.copy()
+        d.update(dict2)
+        return d

--- a/actions/get_job_params.py
+++ b/actions/get_job_params.py
@@ -2,8 +2,9 @@ from lib import action
 
 
 class GetJobParams(action.JenkinsBaseAction):
-    def run(self, project, params):
-
+    def run(self, project, params, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
         job_info = self.jenkins.get_job_info(project, depth=0, fetch_all_builds='False')
         try:
             job_actions = job_info['actions']

--- a/actions/get_job_params.yaml
+++ b/actions/get_job_params.yaml
@@ -17,4 +17,5 @@ parameters:
   config_override:
     type: "object"
     required: false
+    secret: true
     description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/get_job_params.yaml
+++ b/actions/get_job_params.yaml
@@ -1,0 +1,16 @@
+---
+name: "get_job_params"
+runner_type: "python-script"
+description: "Retrieve job's params"
+enabled: true
+entry_point: "get_job_params.py"
+parameters:
+  project:
+    type: "string"
+    description: "Name of the Jenkins job"
+    required: true
+  params:
+    type: "object"
+    description: "Params to merge with default values"
+    required: false
+    default: {}

--- a/actions/get_job_params.yaml
+++ b/actions/get_job_params.yaml
@@ -14,3 +14,7 @@ parameters:
     description: "Params to merge with default values"
     required: false
     default: {}
+  config_override:
+    type: "object"
+    required: false
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/get_queue_info.py
+++ b/actions/get_queue_info.py
@@ -1,0 +1,34 @@
+from lib import action
+from jenkins import JenkinsException
+import re
+import urllib
+
+
+class GetQueueInfo(action.JenkinsBaseAction):
+    def run(self, name_pattern, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
+        try:
+            queued_jobs = self.jenkins.get_queue_info()
+        except JenkinsException as e:
+            return False, {'error': str(e)}
+
+        for job in queued_jobs:
+            # Jenkins returns url-encoded names
+            try:
+                job['task']['name_decoded'] = urllib.unquote(job['task']['name'])
+            except KeyError:
+                continue
+
+        if name_pattern is not None:
+            filtered_queued_jobs = []
+            for job in queued_jobs:
+                try:
+                    if re.match(name_pattern, job['task']['name_decoded']):
+                        filtered_queued_jobs.append(job)
+                except KeyError:
+                    continue
+
+            return True, filtered_queued_jobs
+        else:
+            return True, queued_jobs

--- a/actions/get_queue_info.yaml
+++ b/actions/get_queue_info.yaml
@@ -1,0 +1,16 @@
+---
+name: get_queue_info
+runner_type: python-script
+description: "Get Queue Info"
+enabled: true
+entry_point: "get_queue_info.py"
+parameters:
+  name_pattern:
+    type: "string"
+    description: "regex pattern to filter by name"
+    required: false
+  config_override:
+    type: "object"
+    required: false
+    secret: true
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/get_running_builds.py
+++ b/actions/get_running_builds.py
@@ -1,6 +1,7 @@
 from lib import action
 from jenkins import JenkinsException
 import re
+import urllib
 
 
 class GetRunningBuilds(action.JenkinsBaseAction):
@@ -12,10 +13,14 @@ class GetRunningBuilds(action.JenkinsBaseAction):
         except JenkinsException as e:
             return False, {'error': str(e)}
 
+        for build in running_builds:
+            # Jenkins returns url-encoded names
+            build['name_decoded'] = urllib.unquote(build['name'])
+
         if name_pattern is not None:
             filtered_running_builds = []
             for build in running_builds:
-                if re.match(name_pattern, build['name']):
+                if re.match(name_pattern, build['name_decoded']):
                     filtered_running_builds.append(build)
 
             return True, filtered_running_builds

--- a/actions/get_running_builds.py
+++ b/actions/get_running_builds.py
@@ -4,7 +4,9 @@ import re
 
 
 class GetRunningBuilds(action.JenkinsBaseAction):
-    def run(self, name_pattern):
+    def run(self, name_pattern, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
         try:
             running_builds = self.jenkins.get_running_builds()
         except JenkinsException as e:

--- a/actions/get_running_builds.yaml
+++ b/actions/get_running_builds.yaml
@@ -12,4 +12,5 @@ parameters:
   config_override:
     type: "object"
     required: false
+    secret: true
     description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/get_running_builds.yaml
+++ b/actions/get_running_builds.yaml
@@ -9,3 +9,7 @@ parameters:
     type: "string"
     description: "regex pattern to filter by name"
     required: false
+  config_override:
+    type: "object"
+    required: false
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/install_plugin.py
+++ b/actions/install_plugin.py
@@ -2,5 +2,7 @@ from lib import action
 
 
 class InstallPlugin(action.JenkinsBaseAction):
-    def run(self, plugin):
+    def run(self, plugin, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
         return self.jenkins.install_plugin(plugin, include_dependencies='True')

--- a/actions/install_plugin.yaml
+++ b/actions/install_plugin.yaml
@@ -12,4 +12,5 @@ parameters:
   config_override:
     type: "object"
     required: false
+    secret: true
     description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/install_plugin.yaml
+++ b/actions/install_plugin.yaml
@@ -9,3 +9,7 @@ parameters:
     type: "string"
     description: "Name of the plugin to install"
     required: true
+  config_override:
+    type: "object"
+    required: false
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -11,10 +11,20 @@ class JenkinsBaseAction(Action):
         super(JenkinsBaseAction, self).__init__(config)
         self.jenkins = self._get_client()
 
+    def config_override(self, new_config):
+        self.config = new_config
+        self.jenkins = self._get_client()
+
     def _get_client(self):
         url = self.config['url']
-        username = self.config['username']
-        password = self.config['password']
+        try:
+            username = self.config['username']
+        except KeyError:
+            username = None
+        try:
+            password = self.config['password']
+        except KeyError:
+            password = None
 
         client = jenkins.Jenkins(url, username, password)
         return client

--- a/actions/list_jobs.py
+++ b/actions/list_jobs.py
@@ -2,5 +2,7 @@ from lib import action
 
 
 class ListJobs(action.JenkinsBaseAction):
-    def run(self):
+    def run(self, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
         return self.jenkins.get_jobs()

--- a/actions/list_jobs.yaml
+++ b/actions/list_jobs.yaml
@@ -8,4 +8,5 @@ parameters:
   config_override:
     type: "object"
     required: false
+    secret: true
     description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/list_jobs.yaml
+++ b/actions/list_jobs.yaml
@@ -4,3 +4,8 @@ runner_type: python-script
 description: "List Jenkins jobs"
 enabled: true
 entry_point: "list_jobs.py"
+parameters:
+  config_override:
+    type: "object"
+    required: false
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/list_jobs_regex.py
+++ b/actions/list_jobs_regex.py
@@ -2,7 +2,9 @@ from lib import action
 
 
 class GetJobInfoRegex(action.JenkinsBaseAction):
-    def run(self, pattern):
+    def run(self, pattern, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
         result = ''
         for v in self.jenkins.get_job_info_regex(pattern, depth=0, folder_depth=0):
             result = result + v['displayName'] + '\n'

--- a/actions/list_jobs_regex.yaml
+++ b/actions/list_jobs_regex.yaml
@@ -12,4 +12,5 @@ parameters:
   config_override:
     type: "object"
     required: false
+    secret: true
     description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/list_jobs_regex.yaml
+++ b/actions/list_jobs_regex.yaml
@@ -9,3 +9,7 @@ parameters:
     type: "string"
     description: "regex pattern"
     required: true
+  config_override:
+    type: "object"
+    required: false
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/rebuild_last_job.py
+++ b/actions/rebuild_last_job.py
@@ -2,7 +2,9 @@ from lib import action
 
 
 class RebuildLastJob(action.JenkinsBaseAction):
-    def run(self, project):
+    def run(self, project, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
         last_number = self.jenkins.get_job_info(project)['lastCompletedBuild']['number']
         binfo_all = self.jenkins.get_job_info(project, last_number)['lastStableBuild']['actions']
         for p in binfo_all:

--- a/actions/rebuild_last_job.yaml
+++ b/actions/rebuild_last_job.yaml
@@ -9,3 +9,7 @@ parameters:
     type: "string"
     description: "Name of the Jenkins job"
     required: true
+  config_override:
+    type: "object"
+    required: false
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/rebuild_last_job.yaml
+++ b/actions/rebuild_last_job.yaml
@@ -12,4 +12,5 @@ parameters:
   config_override:
     type: "object"
     required: false
+    secret: true
     description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/stop_build.py
+++ b/actions/stop_build.py
@@ -3,7 +3,9 @@ from jenkins import NotFoundException
 
 
 class StopBuild(action.JenkinsBaseAction):
-    def run(self, project, number):
+    def run(self, project, number, config_override=None):
+        if config_override is not None:
+            self.config_override(config_override)
         try:
             return self.jenkins.stop_build(project, number)
         except NotFoundException as e:

--- a/actions/stop_build.yaml
+++ b/actions/stop_build.yaml
@@ -15,4 +15,5 @@ parameters:
   config_override:
     type: "object"
     required: false
+    secret: true
     description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/actions/stop_build.yaml
+++ b/actions/stop_build.yaml
@@ -4,11 +4,15 @@ description: "Stop a running Jenkins build"
 enabled: true
 entry_point: "stop_build.py"
 parameters:
-    project:
-        type: "string"
-        description: "Name of Jenkins job"
-        required: true
-    number:
-        type: "integer"
-        description: "Jenkins build number for the job"
-        required: true
+  project:
+    type: "string"
+    description: "Name of Jenkins job"
+    required: true
+  number:
+    type: "integer"
+    description: "Jenkins build number for the job"
+    required: true
+  config_override:
+    type: "object"
+    required: false
+    description: "Override pack configuration by providing an object with url, username and password keys and appropriate values"

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - jenkins
   - continuous deployment
   - CICD
-version: 0.7.1
+version: 0.7.2
 author: James Fryman
 email: james@stackstorm.com
 contributors:

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - jenkins
   - continuous deployment
   - CICD
-version: 0.7.3
+version: 0.7.4
 author: James Fryman
 email: james@stackstorm.com
 contributors:

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - jenkins
   - continuous deployment
   - CICD
-version: 0.7.5
+version: 0.7.6
 author: James Fryman
 email: james@stackstorm.com
 contributors:

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - jenkins
   - continuous deployment
   - CICD
-version: 0.7.4
+version: 0.7.5
 author: James Fryman
 email: james@stackstorm.com
 contributors:

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - jenkins
   - continuous deployment
   - CICD
-version: 0.7.2
+version: 0.7.3
 author: James Fryman
 email: james@stackstorm.com
 contributors:

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - jenkins
   - continuous deployment
   - CICD
-version: 0.7.0
+version: 0.7.1
 author: James Fryman
 email: james@stackstorm.com
 contributors:

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
   - CICD
 version: 0.7.6
 author: James Fryman
-email: james@stackstorm.com
+email: info@stackstorm.com
 contributors:
   - Igor Cherkaev <emptywee@gmail.com>


### PR DESCRIPTION
This PR includes the following releases:

# 0.7.6

- If `build_job_enh` fails and `queue_id` is known, include it in the result to let users follow up later.

# 0.7.5

- Added `get_queue_info` action.
- Added `cancel_queued_build` action.

# 0.7.4

- `get_running_builds` now decodes/unquotes jobs' names and adds them as `name_decoded` into the resulting array.

# 0.7.3

Security release.
- `config_override` optional parameter is marked as secret so whatever is provided there is not exposed in the UI.

# 0.7.2

- All actions got `config_override` optional parameter to support multi-tenancy. The parameter takes an object with `url`, `username` and `password` keys with appropriate values to contact arbitrary Jenkins instance instead of the one configured in the global pack configuration. Addresses #3 

# 0.7.1

- Added `get_job_params` action to get all params of a certain job and their default values, and optionally merge it with user provided params.
